### PR TITLE
test for metadata existence in from_metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.egg-info/
 dist/
+.eggs/

--- a/s3_encryption/envelope.py
+++ b/s3_encryption/envelope.py
@@ -34,9 +34,11 @@ class EncryptionEnvelope(dict):
         return json.dumps(self)
 
     def from_metadata(self, metadata):
-        self['x-amz-key'] = metadata.get('x-amz-key', None)
-        self['x-amz-iv'] = metadata.get('x-amz-iv', None)
-        self['x-amz-matdesc'] = metadata.get('x-amz-matdesc', None)
+        self['x-amz-key'] = metadata.get('x-amz-key')
+        self['x-amz-iv'] = metadata.get('x-amz-iv')
+        self['x-amz-matdesc'] = metadata.get('x-amz-matdesc')
+        if not (self['x-amz-key'] and self['x-amz-iv'] and self['x-amz-matdesc']):
+            raise Exception('metadata keys are required for decryption.')
 
     @classmethod
     def encode64(self, data):


### PR DESCRIPTION
- This prevents an esoteric error deep inside Crypto (`Only byte strings can be passed to C code`). It's just a simple test, in the future it might be worthwhile to validate the data (especially matdesc, which gets json-decoded).
- removing the get(.., None) argument, as None is the default when get(..) is called.
- add pip artifacts to gitignore.

Fixes #2
